### PR TITLE
Implement `IntoFuture` for `&Lazy` & `Pin<&Lazy>`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["rust-patterns", "memory-management"]
 
 [features]
 critical-section = ['dep:critical-section']
+nightly = []
 std = []
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,11 @@
 //!
 //! This is currently a no-op, but might in the future be used to expose APIs that depends on
 //! types only in `std`.  It does *not* control the locking implementation.
+//!
+//! ## The `nightly` feature
+//!
+//! This gates the implementation of `IntoFuture for `&Lazy<T, F>` and `Pin<&Lazy<T, F>>`.
+//! These implementations currently require `#![feature(impl_trait_in_assoc_type)]`.
 
 // How it works:
 //
@@ -87,6 +92,7 @@
 // of wakers is not worth the extra complexity and locking in the common case where the QueueRef
 // was dropped due to a successful initialization.
 
+#![cfg_attr(feature = "nightly", feature(impl_trait_in_assoc_type))]
 #![cfg_attr(feature = "critical-section", no_std)]
 extern crate alloc;
 
@@ -1129,5 +1135,35 @@ impl<T: fmt::Debug, F> fmt::Debug for Lazy<T, F> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let value = self.try_get();
         fmt.debug_struct("Lazy").field("value", &value).field("inner", &self.inner).finish()
+    }
+}
+
+#[cfg(feature = "nightly")]
+impl<'a, T, F> core::future::IntoFuture for &'a Lazy<T, F>
+where
+    F: Future<Output = T> + Unpin,
+{
+    type Output = &'a T;
+
+    type IntoFuture = impl Future<Output = Self::Output>;
+
+    #[inline]
+    fn into_future(self) -> Self::IntoFuture {
+        self.get_unpin()
+    }
+}
+
+#[cfg(feature = "nightly")]
+impl<'a, T, F> core::future::IntoFuture for Pin<&'a Lazy<T, F>>
+where
+    F: Future<Output = T>,
+{
+    type Output = Pin<&'a T>;
+
+    type IntoFuture = impl Future<Output = Self::Output>;
+
+    #[inline]
+    fn into_future(self) -> Self::IntoFuture {
+        self.get()
     }
 }


### PR DESCRIPTION
Adds implementations of `IntoFuture` for `&Lazy` and `Pin<&Lazy>`,  which forward to `get_unpin()` and `get()`, respectively. This allows `await`ing on the `Lazy` directly, analogously to the `Deref` impl of the sync `Lazy`.

Unfortunately, these impls currently require nightly Rust to write (for `impl_trait_in_assoc_type`). Therefore, they are gated behind a `nightly` crate feature. Feel free to close or postpone this PR if you don't want that.